### PR TITLE
Fix channel_db._data if new is called before get

### DIFF
--- a/src/channel_db.py
+++ b/src/channel_db.py
@@ -38,7 +38,7 @@ class ChannelDb(object):
 
     def new(self, key, value):
         """Save a new record in both memory (self._data) and the db-channel."""
-        self._data.setdefault(key, []).append(value)
+        self._data.setdefault(key, self.get(key)).append(value)
 
         self.server.flow.send_message(
             cid=self._get_or_create_db_channel(),


### PR DESCRIPTION
- [ ] @qdonnellan 

Currently if ChannelDb.new() is called before ChannelDb.get() on a key, future .get calls ignore all previous (stored on server) values for that key.  This fixes that by using .get to generate the default.